### PR TITLE
More details for contributing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
-Protobuf definitions for various projects, including [swift-homomorphic-encryption](https://github.com/apple/swift-homomorphic-encryption-protobuf)
+Protobuf definitions for various projects, including [swift-homomorphic-encryption](https://github.com/apple/swift-homomorphic-encryption)
 
 ## Contributing
+Welcome to the Swift Homomorphic Encryption community!
+Thanks for your interest in contributing.
+We would love contributions in the form of feedback via [GitHub Issues](https://github.com/apple/swift-homomorphic-encryption-protobuf/issues), pull requests with new features, bug fixes, documentation (including fixing typos!), and your ideas.
+If it's a big change, please start with an Issue.
 
 Before contributing, please run [`pre-commit`](https://pre-commit.com), e.g. via `pre-commit run --all-files`. This will perform some basic formatting checks.
 
 To install `pre-commit`, follow instructions in https://pre-commit.com/. We recommend `brew install pre-commit`.
 
-## Test
-
-To test your changes, generate the protos using `protoc` in a tmp folder.
-
-```bash
-protoc --python_out /tmp *.proto
-```
+### Pull Requests:
+Before making a commit for a pull request, please run `pre-commit install`.
+Then on each commit some basic formatting checks will be run.


### PR DESCRIPTION
The README's short enough, I don't think we need a separate CONTRIBUTING.md

The testing instructions `protoc --python_out /tmp *.proto` were vague so I think we can remove them. 