### PR TITLE
Fix CI for copyright header

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-# Copyright 2024 Apple Inc. and the Swift Homomorphic Encryption project authors
+# Copyright 2024-2025 Apple Inc. and the Swift Homomorphic Encryption project authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -35,7 +35,20 @@ jobs:
     - name: Install pre-commit
       run: pip install pre-commit
     - name: Pre-commit checks
-      # CI will commit to `main`
+      # CI will commit to `main`, insert-license tested separately
       run: >
-        SKIP=no-commit-to-branch
+        SKIP=no-commit-to-branch,insert-license
         pre-commit run --all-files
+  insert-license:
+    timeout-minutes: 1
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 2
+    - name: Install pre-commit
+      run: pip install pre-commit
+    - name: List changed files
+      run: git diff --name-only HEAD~1
+    - name: Run license check
+      run: pre-commit run insert-license --files $(git diff --name-only HEAD~1)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024 Apple Inc. and the Swift Homomorphic Encryption project authors
+# Copyright 2024-2025 Apple Inc. and the Swift Homomorphic Encryption project authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
 
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
     -   id: fix-byte-order-marker
     -   id: check-case-conflict
@@ -28,7 +28,7 @@ repos:
     -   id: no-commit-to-branch
         args: [--branch, main]
 -   repo: https://github.com/crate-ci/typos
-    rev: v1.22.9
+    rev: v1.29.3
     hooks:
     -   id: typos
 -   repo: https://github.com/Lucas-C/pre-commit-hooks
@@ -43,6 +43,7 @@ repos:
            - --comment-style
            - //
            - --allow-past-years
+           - --use-current-year
     -   id: insert-license
         name: insert-license-yaml
         'types_or': [yaml]
@@ -50,8 +51,9 @@ repos:
            - --license-filepath
            - copyright-header.txt
            - --allow-past-years
+           - --use-current-year
 -   repo: https://github.com/bufbuild/buf
-    rev: v1.36.0
+    rev: v1.48.0
     hooks:
       - id: buf-lint
       - id: buf-format

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ Thanks for your interest in contributing.
 We would love contributions in the form of feedback via [GitHub Issues](https://github.com/apple/swift-homomorphic-encryption-protobuf/issues), pull requests with new features, bug fixes, documentation (including fixing typos!), and your ideas.
 If it's a big change, please start with an Issue.
 
-Before contributing, please run [`pre-commit`](https://pre-commit.com), e.g. via `pre-commit run --all-files`. This will perform some basic formatting checks.
-
-To install `pre-commit`, follow instructions in https://pre-commit.com/. We recommend `brew install pre-commit`.
+Before contributing, please install [`pre-commit`](https://pre-commit.com), e.g. via `brew install pre-commit`.
+Then run `pre-commit install` to install pre-commit for the repository.
+Then on each commit, some basic formatting checks will be run.
 
 ### Pull Requests:
 Before making a commit for a pull request, please run `pre-commit install`.


### PR DESCRIPTION
https://github.com/apple/swift-homomorphic-encryption-protobuf/actions/runs/12602141867/job/35124635278?pr=16#step:5:13 has an example run which correctly detects a missing `-2025`.