### PR TITLE
Add OPRF proto messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 # Ignore generated files
 *.pb.swift
+
+.DS_Store
 .idea

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,6 +52,14 @@ repos:
            - copyright-header.txt
            - --allow-past-years
            - --use-current-year
+    -   id: insert-license
+        name: insert-license-sh
+        files: \.sh$
+        args:
+           - --license-filepath
+           - copyright-header.txt
+           - --allow-past-years
+           - --use-current-year
 -   repo: https://github.com/bufbuild/buf
     rev: v1.48.0
     hooks:

--- a/apple/swift_homomorphic_encryption/api/pir/v1/api.proto
+++ b/apple/swift_homomorphic_encryption/api/pir/v1/api.proto
@@ -1,4 +1,4 @@
-// Copyright 2024 Apple Inc. and the Swift Homomorphic Encryption project authors
+// Copyright 2024-2025 Apple Inc. and the Swift Homomorphic Encryption project authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -69,6 +69,8 @@ message Request {
   oneof request {
     // PIR request.
     apple.swift_homomorphic_encryption.api.pir.v1.PIRRequest pir_request = 2;
+    // OPRF request.
+    apple.swift_homomorphic_encryption.api.pir.v1.OPRFRequest oprf_request = 4;
   }
   reserved 3;
 }
@@ -79,6 +81,8 @@ message Response {
   oneof response {
     // Response to a `PIRRequest`.
     apple.swift_homomorphic_encryption.api.pir.v1.PIRResponse pir_response = 1;
+    // Response to `OPRFRequest`.
+    apple.swift_homomorphic_encryption.api.pir.v1.OPRFResponse oprf_response = 3;
   }
   reserved 2;
 }

--- a/apple/swift_homomorphic_encryption/api/pir/v1/pir.proto
+++ b/apple/swift_homomorphic_encryption/api/pir/v1/pir.proto
@@ -1,4 +1,4 @@
-// Copyright 2024 Apple Inc. and the Swift Homomorphic Encryption project authors
+// Copyright 2024-2025 Apple Inc. and the Swift Homomorphic Encryption project authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -92,4 +92,20 @@ message PIRRequest {
 message PIRResponse {
   // Encrypted replies, each of which is a ciphertext vector.
   repeated apple.swift_homomorphic_encryption.v1.SerializedCiphertextVec replies = 1;
+}
+
+// PIR OPRF Request.
+message OPRFRequest {
+  // Serialized query.
+  bytes query_element = 1;
+  // Identifier for PirConfig used to construct this request.
+  bytes config_id = 2;
+}
+
+// PIR OPRF Response.
+message OPRFResponse {
+  // Serialized output of OPRF.
+  bytes evaluated_element = 1;
+  // Proof of OPRF evaluation.
+  bytes proof = 2;
 }

--- a/apple/swift_homomorphic_encryption/api/pnns/v1/api.proto
+++ b/apple/swift_homomorphic_encryption/api/pnns/v1/api.proto
@@ -1,4 +1,4 @@
-// Copyright 2024 Apple Inc. and the Swift Homomorphic Encryption project authors
+// Copyright 2024-2025 Apple Inc. and the Swift Homomorphic Encryption project authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -71,6 +71,7 @@ message Request {
     // PNNS request.
     apple.swift_homomorphic_encryption.api.pnns.v1.PNNSRequest pnns_request = 3;
   }
+  reserved 4;
 }
 
 // Generic response.
@@ -81,4 +82,5 @@ message Response {
     // Response to a `PNNSRequest`.
     apple.swift_homomorphic_encryption.api.pnns.v1.PNNSResponse pnns_response = 2;
   }
+  reserved 3;
 }

--- a/apple/swift_homomorphic_encryption/api/v1/api.proto
+++ b/apple/swift_homomorphic_encryption/api/v1/api.proto
@@ -1,4 +1,4 @@
-// Copyright 2024 Apple Inc. and the Swift Homomorphic Encryption project authors
+// Copyright 2024-2025 Apple Inc. and the Swift Homomorphic Encryption project authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -73,6 +73,8 @@ message Request {
     apple.swift_homomorphic_encryption.api.pir.v1.PIRRequest pir_request = 2;
     // PNNS request.
     apple.swift_homomorphic_encryption.api.pnns.v1.PNNSRequest pnns_request = 3;
+    // OPRF request.
+    apple.swift_homomorphic_encryption.api.pir.v1.OPRFRequest oprf_request = 4;
   }
 }
 
@@ -84,5 +86,7 @@ message Response {
     apple.swift_homomorphic_encryption.api.pir.v1.PIRResponse pir_response = 1;
     // Response to a `PNNSRequest`.
     apple.swift_homomorphic_encryption.api.pnns.v1.PNNSResponse pnns_response = 2;
+    // Response to `OPRFRequest`.
+    apple.swift_homomorphic_encryption.api.pir.v1.OPRFResponse oprf_response = 3;
   }
 }

--- a/apple/swift_homomorphic_encryption/pir/v1/pir.proto
+++ b/apple/swift_homomorphic_encryption/pir/v1/pir.proto
@@ -1,4 +1,4 @@
-// Copyright 2024 Apple Inc. and the Swift Homomorphic Encryption project authors
+// Copyright 2024-2025 Apple Inc. and the Swift Homomorphic Encryption project authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -51,14 +51,16 @@ message PirParameters {
   apple.swift_homomorphic_encryption.v1.EvaluationKeyConfig evaluation_key_config = 8;
   // Key compression strategy.
   KeyCompressionStrategy key_compression_strategy = 9;
-  reserved 10, 11;
+  reserved 10, 11, 12;
 }
 
 // Parameters for keyword PIR.
 message KeywordPirParameters {
   // The number of hash functions used.
   uint64 num_hash_functions = 1;
-  reserved 2, 3;
+  reserved 2;
+  // Symmetric PIR configuration
+  SymmetricPirClientConfig symmetric_pir_client_config = 3;
   // The sharding function to use.
   PIRShardingFunction sharding_function = 4;
 }
@@ -93,4 +95,20 @@ message EncryptedIndices {
   repeated apple.swift_homomorphic_encryption.v1.SerializedCiphertext ciphertexts = 1;
   // Number of PIR calls.
   uint64 num_pir_calls = 2;
+}
+
+// Scheme used for encrypting database entries in Symmetric PIR.
+enum SymmetricPirConfigType {
+  // Unspecified config type.
+  SYMMETRIC_PIR_CONFIG_TYPE_UNSPECIFIED = 0;
+  // OPRF P384 AES-192-GCM, 96-bit nonce, 128-bit tag
+  SYMMETRIC_PIR_CONFIG_TYPE_OPRF_P384_AES_GCM_192_NONCE_96_TAG_128 = 1;
+}
+
+// Client specific PIR configuration for Symmetric PIR
+message SymmetricPirClientConfig {
+  // Server public key
+  bytes server_public_key = 1;
+  // Symmetric PIR config type
+  SymmetricPirConfigType config_type = 2;
 }

--- a/buf.yaml
+++ b/buf.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024 Apple Inc. and the Swift Homomorphic Encryption project authors
+# Copyright 2024-2025 Apple Inc. and the Swift Homomorphic Encryption project authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,15 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: v1
+version: v2
 breaking:
   use:
     - FILE
     - WIRE
-
 lint:
   use:
-    - DEFAULT
+    - STANDARD
     - COMMENTS
     - PACKAGE_NO_IMPORT_CYCLE
   ignore_only:


### PR DESCRIPTION
https://github.com/apple/swift-homomorphic-encryption/pull/144 generated code from these protos, but the protos were never added here.